### PR TITLE
docs(site): 官网首页改造为产品落地页 + CLI 补 doctor/import

### DIFF
--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -1,40 +1,121 @@
 ---
 title: TRNovel
-description: TRNovel 是一个功能强大的终端小说阅读器，支持本地和网络小说阅读。
+description: 终端里的现代小说阅读器 —— 本地与网络小说双修,智能识别分卷目录,AI 一键生成书源,还能 TTS 听书,一个二进制开箱即用。
 template: splash
 hero:
-  tagline: 基于 Rust 和 Ratatui-Kit 构建的现代化终端小说阅读器，专为小说爱好者设计。
+  tagline: 在终端里优雅地读小说。本地 TXT 与网络小说双修,智能识别「卷 → 章」目录,AI 一键生成书源,还能 TTS 听书 —— 一个二进制,开箱即用。
+  image:
+    file: ../../assets/guides/read.png
   actions:
     - text: 快速开始
       link: /TRNovel/guides/intro
       icon: right-arrow
-    - text: 点个 Star 支持我们
+      variant: primary
+    - text: 安装 TRNovel
+      link: /TRNovel/guides/install
+      variant: secondary
+    - text: GitHub
       link: https://github.com/yexiyue/TRNovel
       icon: external
       variant: minimal
 ---
 
-import { Card, CardGrid } from '@astrojs/starlight/components';
+import { Card, CardGrid, LinkCard, Tabs, TabItem, Steps, Aside } from '@astrojs/starlight/components';
+import { Image } from 'astro:assets';
+import readImg from '../../assets/guides/read.png';
+import homeImg from '../../assets/guides/home.png';
+import selectChapterImg from '../../assets/guides/select-chapter.png';
+import ttsImg from '../../assets/guides/tts/novel-tts.png';
 
+## ✨ 核心亮点
 
-<CardGrid stagger>
-	<Card title="本地小说阅读" icon="document">
-		支持本地 TXT 格式小说文件的阅读，自动识别目录结构。
+<CardGrid>
+	<Card title="本地 + 网络双源" icon="open-book">
+		本地 TXT(自动识别 UTF-8 / GBK)与网络小说一站搞定;阅读进度自动记录,`trn -q` 一键回到上次。
 	</Card>
-	<Card title="网络小说源" icon="open-book">
-		通过自定义书源配置，访问网络小说内容。
+	<Card title="智能章节识别 + 分卷" icon="bars">
+		规则引擎告别写死的 `第…章` 正则,准确切分「卷 → 章」,生成可折叠的目录树,长篇也不迷路。
 	</Card>
-	<Card title="历史记录管理" icon="bars">
-		自动记录阅读进度，方便继续阅读。
+	<Card title="AI 一键生成书源 🆕" icon="document">
+		配套 `booksource-generator` skill:把任意小说站 URL 交给 AI,自动逆向出书源 → `trn doctor` 全流程校验 → `trn import` 一键导入即用。做书源不再手写规则。
 	</Card>
-	<Card title="主题自定义" icon="setting">
-		支持自定义主题颜色，打造个性化阅读体验。
+	<Card title="反爬 / 浏览器辅助 🆕" icon="setting">
+		撞上 Cloudflare?复用系统已装浏览器解挑战、领 `cf_clearance` 再交回快请求 —— 能自动就自动,必要时点一下「我是真人」即可。
 	</Card>
-	<Card title="听书功能" icon="star">
-		集成 TTS 语音合成功能，支持听书模式。
+	<Card title="TTS 听书" icon="star">
+		内置 Kokoro 中文语音合成,边听边高亮当前句,解放双眼。
 	</Card>
-	<Card title="跨平台支持" icon="laptop">
-		支持 Windows、macOS 和 Linux 等主流操作系统。
+	<Card title="终端原生 · 跨平台" icon="laptop">
+		Rust + React 式 TUI 框架 [ratatui-kit](https://yexiyue.github.io/ratatui-kit-website/) 构建,单二进制,Windows / macOS / Linux 通吃,主题可自定义。
 	</Card>
 </CardGrid>
 
+## 🚀 30 秒上手
+
+<Tabs syncKey="install">
+	<TabItem label="一键脚本">
+		```bash
+		# macOS / Linux
+		curl --proto '=https' --tlsv1.2 -LsSf https://github.com/yexiyue/TRNovel/releases/latest/download/trnovel-installer.sh | sh
+		```
+	</TabItem>
+	<TabItem label="Homebrew">
+		```bash
+		brew install yexiyue/tap/trnovel
+		```
+	</TabItem>
+	<TabItem label="cargo">
+		```bash
+		cargo install trnovel
+		```
+	</TabItem>
+</Tabs>
+
+装好后即可开读:
+
+```bash
+trn            # 打开主页
+trn -q         # 续读上一次的位置
+trn -n         # 网络小说
+trn -l ./书库   # 读某个目录下的本地小说
+```
+
+<Aside type="tip">还有 `trn doctor <书源.json>` 体检书源、`trn import <书源.json>` 一键导入。完整命令见 [CLI 参考](/TRNovel/reference/cli)。</Aside>
+
+## 🤖 让 AI 帮你做书源(独一份)
+
+别人做书源要手写一堆规则,TRNovel 把这件事交给 AI —— 配套 `booksource-generator` skill 把「逆向 → 校验 → 导入」串成闭环:
+
+<Steps>
+1. 把小说站 URL 交给装了 skill 的 AI,它探站、逆向出 search / 目录 / 正文 的选择器;
+2. `trn doctor` 全流程体检,逐项 ✓/✗ 迭代到全绿(连分卷、反爬都帮你处理);
+3. `trn import` 导入 —— 立刻在 `trn -n` 里读到这个站。
+</Steps>
+
+书源是**结构化 JSON、对 AI 友好**,schema 由 Rust 类型自动生成、永不漂移。详见 [书源参考](/TRNovel/book-source/intro) 与 [反爬与浏览器辅助](/TRNovel/reference/anti-scraping)。
+
+## 📸 看它跑起来
+
+<CardGrid>
+	<Card title="沉浸式阅读">
+		<Image src={readImg} alt="TRNovel 阅读界面" />
+	</Card>
+	<Card title="清爽主页">
+		<Image src={homeImg} alt="TRNovel 主页" />
+	</Card>
+	<Card title="可折叠分卷目录">
+		<Image src={selectChapterImg} alt="分卷目录树" />
+	</Card>
+	<Card title="TTS 听书">
+		<Image src={ttsImg} alt="TTS 听书" />
+	</Card>
+</CardGrid>
+
+## 📚 了解更多
+
+<CardGrid>
+	<LinkCard title="使用指南" description="从安装到阅读、网络小说、听书、主题,逐步上手。" href="/TRNovel/guides/intro" />
+	<LinkCard title="书源参考" description="书源结构、规则语法,以及如何制作一个书源。" href="/TRNovel/book-source/intro" />
+	<LinkCard title="反爬与浏览器辅助" description="Cloudflare 挑战的工作方式与降级策略。" href="/TRNovel/reference/anti-scraping" />
+	<LinkCard title="CLI 命令参考" description="trn 的全部子命令与参数。" href="/TRNovel/reference/cli" />
+</CardGrid>

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -79,3 +79,34 @@ trnovel -l [PATH]
 ```bash
 trnovel -H
 ```
+
+### `doctor` (`-d`)
+
+体检书源：对书源 JSON 跑完整流程（配置 / 浏览 / 书详情 / 目录 / 正文 / 搜索），逐项报告 ✓/✗/○。
+用于校验 AI 生成的书源是否可用；被反爬挑战拦截的端点会给出精确提示而非笼统失败。
+
+用法:
+
+```bash
+trnovel doctor <书源.json>
+```
+
+参数:
+
+- `<书源.json>`: 待校验的书源 JSON 文件路径
+
+### `import` (`-i`)
+
+导入书源：把书源 JSON（本地文件或 URL）写入 `~/.novel/book_sources.json`，使其在网络小说（`-n`）里可直接选用。
+按 `url` + `name` 去重（同名覆盖，便于反复迭代同一书源）。是「AI 生成 → `doctor` 校验 → 导入即用」闭环的最后一步。
+
+用法:
+
+```bash
+trnovel import <书源.json>          # 本地文件
+trnovel import https://…/source.json   # 也支持 URL
+```
+
+参数:
+
+- `<source>`: 书源 JSON 文件路径或 URL


### PR DESCRIPTION
## Why
官网首页偏文档化、缺产品亮点。改造成**产品落地页**,并把新能力(AI 生成书源、反爬、分卷)讲清楚。

## What
- **首页 `index.mdx`**:hero 配阅读截图 + 更有力的 tagline + 三个 CTA(快速开始/安装/GitHub);「核心亮点」卡片重写,突出 **AI 一键生成书源**、**反爬/浏览器辅助**、**智能章节识别+分卷** 等差异化能力;新增「30 秒上手」(一键脚本/Homebrew/cargo)、「让 AI 帮你做书源」闭环(Steps)、截图展示、了解更多导航。
- **`reference/cli.md`**:补上新子命令 `doctor`(-d)与 `import`(-i)。

## 验证
本地 `pnpm build` 通过(17 页,无报错);图标/资源/组件均有效。Pages 部署在合并后由现有工作流执行。