### PR TITLE
docs(book-source): 按 v2 全面重写书源参考并重新拆分

### DIFF
--- a/docs/src/content/docs/book-source/intro.md
+++ b/docs/src/content/docs/book-source/intro.md
@@ -2,82 +2,79 @@
 title: 介绍
 sidebar:
     order: 1
-lastUpdated: 2025-10-29
+lastUpdated: 2026-06-02
 ---
 
-## 什么是书源？
+书源是 TRNovel 接入网络小说的方式:一份**声明式 JSON**,告诉引擎如何在某个网站上**搜索、浏览分类、读取书籍信息、列出目录(含分卷)、抓取正文**。
 
-书源是 TRNovel 获取网络小说内容的重要方式。 它们定义了如何从不同的网站抓取小说章节和元数据。通过使用书源，TRNovel 能够支持多种小说网站，让用户可以方便地阅读和管理他们喜欢的小说。书源的本质是一个JSON 爬虫配置文件，描述了如何从特定网站提取小说内容。
+## 设计:结构化、对 AI 友好
 
-## 示例
+TRNovel 的书源是 `trnovel-booksource/v2` 格式。和传统的「紧凑字符串 DSL」(如 `[property=og:novel:book_name]@content##简介:`)不同,v2 里**每个字段都是一个结构化的「规则」对象**:
 
-```json title="笔趣阁书源示例.json"
+```json
+// 旧式紧凑 DSL(不再使用)
+"name": "[property=og:novel:book_name]@content"
+
+// v2 结构化规则
+"name": { "via": "css", "select": "[property=\"og:novel:book_name\"]", "extract": { "attr": "content" } }
+```
+
+这样做的好处:
+
+- **可读、可校验**:字段含义一目了然,JSON Schema 能静态约束。
+- **对 AI 友好**:结构清晰,AI 能可靠地生成与修改 —— 配套的 `booksource-generator` skill 可以**据网站 URL 自动生成书源**(见[制作书源](/TRNovel/book-source/make))。
+- **schema 永不漂移**:`book-source.schema.json` 由 Rust 类型**自动生成**,与引擎行为始终一致。
+
+## 顶层结构一览
+
+| 字段 | 必填 | 说明 |
+|------|:---:|------|
+| `schema` | ✅ | 固定为 `"trnovel-booksource/v2"` |
+| `name` | ✅ | 书源名称 |
+| `url` | ✅ | 站点根地址(模板里的 `{{base}}`) |
+| `group` | | 分组(便于管理) |
+| `http` | | 请求配置:headers / cookies / warmup / charset / 取页模式 / 超时 / 重试 / 限速 |
+| `search` | | 搜索能力 |
+| `explore` | | 分类浏览能力 |
+| `bookInfo` | ✅ | 书详情页的字段抽取 |
+| `toc` | ✅ | 目录(章节 + 分卷) |
+| `content` | ✅ | 正文抽取 |
+| `samples` | | 黄金样例,驱动 `doctor` 校验与运行期自愈 |
+
+字段详解见[书源结构](/TRNovel/book-source/structure),规则语法见[规则语法](/TRNovel/book-source/rules)。
+
+## 最小示例
+
+```json title="minimal.v2.json"
 {
-    "bookSourceGroup": "精品",
-    "bookSourceName": "笔趣阁",
-    "bookSourceUrl": "https://www.4c7f720b2.lol",
-    "lastUpdateTime": 1736150932184,
-    "searchUrl": "https://www.4c7f720b2.lol/user/hm.html?q={{key}},https://www.4c7f720b2.lol/user/search.html?q={{key}}&so=undefined",
-    "exploreUrl": "[{\"title\":\"玄幻\",\"url\":\"https://www.4c7f720b2.lol/json?sortid=1&page={{page}}\"},{\"title\":\"武侠\",\"url\":\"https://www.4c7f720b2.lol/json?sortid=2&page={{page}}\"},{\"title\":\"都市\",\"url\":\"https://www.4c7f720b2.lol/json?sortid=3&page={{page}}\"},{\"title\":\"历史\",\"url\":\"https://www.4c7f720b2.lol/json?sortid=4&page={{page}}\"},{\"title\":\"网游\",\"url\":\"https://www.4c7f720b2.lol/json?sortid=5&page={{page}}\"},{\"title\":\"科幻\",\"url\":\"https://www.4c7f720b2.lol/json?sortid=6&page={{page}}\"},{\"title\":\"女生\",\"url\":\"https://www.4c7f720b2.lol/json?sortid=7&page={{page}}\"},{\"title\":\"完本\",\"url\":\"https://www.4c7f720b2.lol/json?sortid=8&page={{page}}\"}]",
-    "ruleExploreItem": null,
-    "header": null,
-    "respondTime": null,
-    "httpConfig": {
-        "timeout": null,
-        "header": null,
-        "rateLimit": null
-    },
-    "ruleBookInfo": {
-        "name": "[property=og:novel:book_name]@content",
-        "author": "[property=og:novel:author]@content",
-        "coverUrl": "[property=og:image]@content",
-        "intro": "[property=og:description]@content##简介：",
-        "kind": "[property=og:novel:update_time]@content&&\n[property=og:novel:category]@content&&\n[property=og:novel:status]@content",
-        "lastChapter": "[property=og:novel:latest_chapter_name]@content",
-        "tocUrl": "",
-        "wordCount": ""
-    },
-    "ruleContent": {
-        "content": "id.chaptercontent@html##请收藏本站.*|<a.*</a>|第(.*?)页|\\[爱豆看书\\]|ｍ．２６ｋｓw.ｃｃ"
-    },
-    "ruleExplore": {
-        "bookList": "$.*",
-        "bookUrl": "$.url_list",
-        "name": "$.articlename",
-        "author": "$.author",
-        "coverUrl": "$.url_img",
-        "intro": "$.intro",
-        "kind": "",
-        "lastChapter": "",
-        "tocUrl": "",
-        "wordCount": ""
-    },
-    "ruleSearch": {
-        "bookList": "$.*",
-        "bookUrl": "$.url_list",
-        "name": "$.articlename",
-        "author": "$.author",
-        "coverUrl": "$.url_img",
-        "intro": "$.intro",
-        "kind": "",
-        "lastChapter": "",
-        "tocUrl": "",
-        "wordCount": ""
-    },
-    "ruleToc": {
-        "chapterList": "@css:.listmain dd a[href^=\"/\"]",
-        "chapterName": "tag.a@text",
-        "chapterUrl": "tag.a@href",
-        "isVolume": ""
-    }
+  "schema": "trnovel-booksource/v2",
+  "name": "示例书源",
+  "url": "https://example.com",
+  "bookInfo": {
+    "name": { "via": "css", "select": "h1.book-title", "extract": "text" },
+    "tocUrl": { "via": "css", "select": "a.catalog", "extract": { "attr": "href" } }
+  },
+  "toc": {
+    "list": { "via": "css", "select": ".chapter-list a" },
+    "name": { "via": "raw" },
+    "url": { "via": "css", "select": "a", "extract": { "attr": "href" } }
+  },
+  "content": {
+    "value": { "via": "css", "select": "#content", "extract": "html" }
+  }
 }
 ```
 
-:::note[分卷（可选）]
-`ruleToc.isVolume` 为可选的卷判定规则：当它对某个目录项求值为非空（且不为 `false`/`0`）时，该项会被识别为**卷标题**并在目录中作为分组节点显示，而非可阅读章节。留空（默认）时所有条目均为普通章节，与旧书源行为一致。
-:::
+## 从配置到可用
 
-:::tip[提示]
-由于是网络爬虫配置文件，书源可能会因为网站结构变化而失效。建议定期更新书源以确保其有效性。
-非常欢迎用户贡献和分享新的书源配置文件，以丰富 TRNovel 的书源库。
+```text
+据网站逆向/AI 生成 → trn doctor 校验 → trn import 导入 → trn -n 选用
+```
+
+- 生成与逆向技巧 → [制作书源](/TRNovel/book-source/make)
+- 反爬(Cloudflare 等)的处理 → [反爬与浏览器辅助](/TRNovel/reference/anti-scraping)
+- 命令 → [CLI 参考](/TRNovel/reference/cli)(`doctor` / `import`)
+
+:::tip
+书源是网络爬虫配置,可能因网站结构变化而失效。`samples` 里写上一两本书的期望,`trn doctor` 就能随时体检书源是否仍然有效。
 :::

--- a/docs/src/content/docs/book-source/make.md
+++ b/docs/src/content/docs/book-source/make.md
@@ -1,6 +1,150 @@
 ---
-title: 如何制作
+title: 制作书源
 sidebar:
-    order: 2
-lastUpdated: 2025-10-29
+    order: 4
+lastUpdated: 2026-06-02
 ---
+
+import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
+
+做一个书源有两条路:**让 AI 做**(推荐,最省事)或**手动逆向**。两者最后都用 `trn doctor` 校验、`trn import` 导入。
+
+## 方式一:让 AI 做(推荐)
+
+仓库内置 `booksource-generator` skill(在 `skills/` 下,可用 [`npx skills`](https://github.com/vercel-labs/agent-skills) 安装)。把它装给你的 AI 助手,然后:
+
+<Steps>
+1. 把小说站 URL 交给 AI:「给这个站做个 trnovel 书源 https://…」;
+2. AI 探站、逆向出 search / 浏览 / 书详情 / 目录(含分卷)/ 正文 的选择器,并自动用 `trn doctor` 全流程校验、按 ✓/✗ 迭代到通过(连字符集、反爬都会处理);
+3. AI 跑 `trn import` 导入 —— 立刻在 `trn -n` 里读到这个站。
+</Steps>
+
+skill 内含规则 schema、真实示例与逆向战术手册,生成的书源是结构化 JSON,质量可由 `doctor` 客观保证。
+
+## 方式二:手动逆向
+
+<Steps>
+1. **探站**:抓取代表性页面看结构 —— 首页(找搜索表单)、一本书的详情页、它的目录页、一个搜索结果页、一个分类页。
+
+   ```bash
+   UA='Mozilla/5.0 … Chrome/124.0 Safari/537.36'
+   curl -s -A "$UA" "https://example.com/book/123/" -o page.html
+   grep -oiE 'property="og:[^"]*"|class="[^"]*"' page.html | sort | uniq -c | sort -rn | head
+   ```
+
+2. **逐能力写规则**(语法见[规则语法](/TRNovel/book-source/rules),形态见[书源结构](/TRNovel/book-source/structure)):
+   - **bookInfo**:优先 `og:` meta(`og:novel:book_name` / `og:novel:read_url` / `og:image` …),最稳。
+   - **toc**:用一个 `list` 同时选中卷标题与章节链接,`isVolume` 区分二者,引擎据此切「卷 → 章」。
+   - **content**:定位正文容器(`.article-content` / `#content` …),`extract: "html"`,必要时 `clean` 去页脚。
+   - **search**:从首页 `<form>` 找 action 与参数名;`item` 必须含 `bookUrl`。
+
+3. **判定字符集**:中文乱码就设 `http.charset`(`utf8` / `gbk`);不确定用默认 `auto`。
+
+4. **校验 → 导入**(见下)。
+</Steps>
+
+### 常见坑
+
+- **目录开头的「最新章节」预览**:很多目录页前 N 条是倒序、与正文区重复的预览。用兄弟选择器(如 `#list dl dt:has(a[href*="txt_"]) ~ dd a`)只取正文区之后的章节。
+- **POST 搜索**:不少站需显式带 `"headers": { "Content-Type": "application/x-www-form-urlencoded" }` 才返回结果。
+- **反爬**:撞 Cloudflare 见[反爬与浏览器辅助](/TRNovel/reference/anti-scraping);先找未被挑战的等价入口,再考虑 `fetcher` 模式。
+
+## 校验:`trn doctor`
+
+对书源跑完整流程,逐项报告 ✓/✗/○,**一次只修一个 ✗ 对应的规则,重跑直到全绿**:
+
+```bash
+trn doctor my-source.v2.json
+```
+
+```text
+书源诊断:哔哩小说
+  ✓ 配置     书源「哔哩小说」
+  ✓ 浏览     20 本(分类「最近更新」)
+  ✓ 书详情    蛊真人
+  ✓ 目录     8 卷 / 2336 章
+  ✓ 正文     2402 字
+  ✓ 搜索     「蛊真人」→ 16 本
+```
+
+无 `samples` 时,doctor 会用浏览结果探一本书来测读取链路,所以先把 `explore` 或 `samples` 做对能解锁后面几项。
+
+## 导入:`trn import`
+
+校验通过后导入,使其在网络小说里可选用(按 `url`+`name` 去重,同名覆盖):
+
+```bash
+trn import my-source.v2.json     # 本地文件
+trn import https://…/source.json # 也支持 URL
+trn -n                            # 在网络小说里选用
+```
+
+## 完整示例
+
+下面是哔哩小说(bilixs)的完整 v2 书源,覆盖 search / explore / bookInfo / toc(分卷)/ content / samples,可作为模板:
+
+```json title="bilixs.v2.json"
+{
+  "schema": "trnovel-booksource/v2",
+  "name": "哔哩小说",
+  "group": "测试",
+  "url": "https://www.bilixs.com",
+  "http": {
+    "headers": {
+      "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36",
+      "Referer": "https://www.bilixs.com/"
+    },
+    "warmup": ["https://www.bilixs.com/"],
+    "charset": "auto",
+    "timeout": 15000,
+    "retry": { "max": 2, "backoffMs": 500 }
+  },
+  "search": {
+    "request": { "url": { "template": "{{base}}/search.html?searchkey={{key}}" }, "method": "GET" },
+    "list": { "via": "css", "select": ".module-search-item" },
+    "item": {
+      "bookUrl": { "via": "css", "select": "h3 a", "extract": { "attr": "href" } },
+      "name": { "via": "css", "select": "h3 a", "extract": "text" },
+      "cover": { "via": "css", "select": ".module-item-pic img", "extract": { "attr": "data-src" } }
+    }
+  },
+  "explore": {
+    "categories": [
+      { "title": "最近更新", "url": { "template": "{{base}}/book/lastupdate_0_1_0_0_0_0_0_{{page}}_0.html" } }
+    ],
+    "list": { "via": "css", "select": ".module-item" },
+    "item": {
+      "name": { "via": "css", "select": ".module-item-title", "extract": "text" },
+      "tocUrl": { "via": "css", "select": ".module-item-title", "extract": { "attr": "href" } }
+    }
+  },
+  "bookInfo": {
+    "name": { "via": "css", "select": "[property=\"og:novel:book_name\"]", "extract": { "attr": "content" } },
+    "author": { "via": "css", "select": "[property=\"og:novel:author\"]", "extract": { "attr": "content" } },
+    "cover": { "via": "css", "select": "[property=\"og:image\"]", "extract": { "attr": "content" } },
+    "intro": { "via": "css", "select": "[property=\"og:description\"]", "extract": { "attr": "content" } },
+    "tocUrl": { "via": "css", "select": "[property=\"og:novel:read_url\"]", "extract": { "attr": "content" } }
+  },
+  "toc": {
+    "list": { "via": "css", "select": ".box > h2.module-title.type, .box a.module-row-text" },
+    "name": { "firstOf": [
+      { "via": "css", "select": ".module-row-title", "extract": "text" },
+      { "via": "css", "select": "h2", "extract": "text" }
+    ] },
+    "url": { "via": "css", "select": "a", "extract": { "attr": "href" } },
+    "isVolume": { "via": "css", "select": "h2", "extract": "text" },
+    "maxPages": 1
+  },
+  "content": {
+    "value": {
+      "via": "css", "select": ".article-content", "extract": "html",
+      "clean": [ { "regex": "请收藏本站[^<\\n]*", "replace": "" }, { "trim": true } ]
+    },
+    "maxPages": 1
+  },
+  "samples": [
+    { "bookUrl": "/novel/guzhenren.html",
+      "expect": { "name": "蛊真人", "volumes": 8, "minChapters": 2000, "minContentChars": 500 } }
+  ]
+}
+```

--- a/docs/src/content/docs/book-source/rule.md
+++ b/docs/src/content/docs/book-source/rule.md
@@ -1,6 +1,0 @@
----
-title: 规则
-sidebar:
-    order: 3
-lastUpdated: 2025-10-29
----

--- a/docs/src/content/docs/book-source/rules.md
+++ b/docs/src/content/docs/book-source/rules.md
@@ -1,0 +1,92 @@
+---
+title: 规则语法
+sidebar:
+    order: 3
+lastUpdated: 2026-06-02
+---
+
+书源里几乎每个字段(书名、URL、章节列表……)都是一条**规则**。规则要么是一次**抽取(叶子)**,要么是一个**组合子**。本页是规则的完整语法。
+
+## 叶子规则:一次抽取
+
+```json
+{ "via": "css", "select": "h3 a", "extract": "text" }
+```
+
+| 字段 | 说明 |
+|------|------|
+| `via` | 抽取后端:`css`(默认)/ `xpath` / `json`(JSONPath)/ `regex`(fancy-regex)/ `raw`(直接用上下文值,不选择) |
+| `select` | 选择器:CSS 选择器 / JSONPath / 正则;`via: "raw"` 时省略。**HTML 的 `select` 是 self-or-descendant 语义**(省略 `select` = 元素自身) |
+| `index` | 取第 N 个匹配(值规则),负数从末尾 |
+| `extract` | 取值方式,见下 |
+| `clean` | 有序后处理流水线,见下 |
+
+### extract —— 取什么值
+
+- `"text"`(默认)、`"ownText"`、`"html"`、`"innerHtml"`、`"outerHtml"`
+- 取属性:`{ "attr": "href" }`(也常用 `src` / `data-src` / `content`)
+
+```json
+{ "via": "css", "select": "a",   "extract": { "attr": "href" } }   // 取链接
+{ "via": "css", "select": ".c", "extract": "html" }                // 标签转换行后清理
+{ "via": "json", "select": "$.url_list" }                          // JSONPath
+```
+
+### clean —— 后处理流水线
+
+按顺序执行,每步用其中一种:
+
+```json
+"clean": [
+  { "regex": "请收藏本站[^<\\n]*", "replace": "" },   // 正则替换(replace 默认空串)
+  { "trim": true },                                   // 去首尾空白
+  { "prepend": "https://example.com" },               // 前缀
+  { "append": "?nocache=1" }                          // 后缀
+]
+```
+
+## 组合子
+
+| 组合子 | 作用 | 例 |
+|--------|------|----|
+| `firstOf` | 返回**首个非空**子规则结果(回退 / 兼容多结构) | `{ "firstOf": [ {规则A}, {规则B} ] }` |
+| `concat` | **拼接**非空子规则结果,可选 `join` | `{ "concat": [ {A}, {B} ], "join": " · " }` |
+| `literal` | 字面量值 | `{ "literal": "玄幻" }` |
+| `template` | 模板插值 | `{ "template": "{{base}}/s?q={{key}}" }` |
+
+```json
+// 章节名:优先取 .module-row-title,没有则退回 h2
+"name": { "firstOf": [
+  { "via": "css", "select": ".module-row-title", "extract": "text" },
+  { "via": "css", "select": "h2", "extract": "text" }
+] }
+```
+
+## URL 与模板变量
+
+URL 字段(`search.request.url`、`explore.categories[].url` 等)可以是**字符串模板**或一条规则:
+
+```json
+"url": { "template": "{{base}}/search.html?searchkey={{key}}" }
+```
+
+内置变量:
+
+| 变量 | 含义 |
+|------|------|
+| `{{base}}` | 站点根(顶层 `url`,已去尾斜杠) |
+| `{{key}}` | 搜索词 |
+| `{{page}}` | 当前页码 |
+| `{{pageSize}}` | 每页条数 |
+
+请求级 `vars`(命名捕获)也可在模板中引用。相对 URL 引擎会自动补全成绝对地址,**抽取 `href` 时保留相对路径即可**。
+
+## 后端选择
+
+- **`css`**(默认):用 [dom_query](https://crates.io/crates/dom_query) 的 CSS 选择器,支持 `:has()`/`:contains()` 等扩展伪类。
+- **`json`**:目标是 JSON 接口时用 JSONPath(如 `$[*]` / `$.url_list`)。
+- **`regex`**:fancy-regex(支持前后向断言)。
+- **`raw`**:直接使用上下文当前值,常用于「列表项本身就是目标值」。
+- `xpath`:占位,暂以 css 为主。
+
+完整字段与取值约束以自动生成的 [`book-source.schema.json`](https://github.com/yexiyue/TRNovel/blob/main/crates/parse-book-source/book-source.schema.json) 为准。

--- a/docs/src/content/docs/book-source/structure.md
+++ b/docs/src/content/docs/book-source/structure.md
@@ -1,0 +1,131 @@
+---
+title: 书源结构
+sidebar:
+    order: 2
+lastUpdated: 2026-06-02
+---
+
+本页讲清楚每个能力块长什么样。每个字段的取值是一条「规则」,规则的写法见[规则语法](/TRNovel/book-source/rules)。完整约束以 [`book-source.schema.json`](https://github.com/yexiyue/TRNovel/blob/main/crates/parse-book-source/book-source.schema.json)(由 Rust 类型自动生成)为准。
+
+## http —— 请求配置
+
+```json
+"http": {
+  "headers":  { "User-Agent": "Mozilla/5.0 …", "Referer": "https://example.com/" },
+  "cookies":  { "key": "value" },
+  "warmup":   ["https://example.com/"],
+  "charset":  "auto",
+  "fetcher":  "auto",
+  "timeout":  15000,
+  "retry":    { "max": 2, "backoffMs": 500 },
+  "rateLimit":{ "maxCount": 1, "perMs": 1000 }
+}
+```
+
+| 字段 | 说明 |
+|------|------|
+| `headers` | 每个请求都带的请求头(常用于 `User-Agent` / `Referer`) |
+| `cookies` | 静态 cookie;也是手动注入 `cf_clearance` 等通行证的落点 |
+| `warmup` | 先 GET 这些页以预热会话 cookie(站点需要先访问首页/某接口才放行时用) |
+| `charset` | `auto`(默认,UTF-8 失败回退 GBK)/ `utf8` / `gbk` / `gb18030` / `big5` |
+| `fetcher` | 取页模式:`auto`(默认,撞反爬才用浏览器)/ `reqwest`(永不开浏览器)/ `browser`(整站走浏览器)。见[反爬](/TRNovel/reference/anti-scraping) |
+| `timeout` | 单请求超时(毫秒) |
+| `retry` | 失败重试:`max` 次数、`backoffMs` 退避 |
+| `rateLimit` | 限速:`perMs` 毫秒内最多 `maxCount` 次 |
+
+## search —— 搜索
+
+```json
+"search": {
+  "request": { "url": { "template": "{{base}}/search.html?searchkey={{key}}" }, "method": "GET" },
+  "list":    { "via": "css", "select": ".module-search-item" },
+  "item": {
+    "bookUrl": { "via": "css", "select": "h3 a", "extract": { "attr": "href" } },
+    "name":    { "via": "css", "select": "h3 a", "extract": "text" },
+    "cover":   { "via": "css", "select": ".module-item-pic img", "extract": { "attr": "data-src" } }
+  }
+}
+```
+
+- `request`:`url`(模板或规则)、`method`(`GET`/`POST`)、可选 `body`、可选 `headers`、可选 `vars`(命名捕获供模板用)。`{{key}}` = 搜索词。
+- `list`:选中**所有结果条目**的规则。
+- `item`:在每个条目上抽字段(同 `bookInfo` 的字段集),**必须含 `bookUrl`**(指向书详情)。
+
+## explore —— 分类浏览
+
+```json
+"explore": {
+  "categories": [ { "title": "玄幻", "url": { "template": "{{base}}/sort/1_{{page}}.html" } } ],
+  "list": { "via": "css", "select": ".module-item" },
+  "item": { "bookUrl": { "…": "…" }, "name": { "…": "…" } }
+}
+```
+
+- `categories`:分类列表,每项 `title` + `url`(常含 `{{page}}` 翻页)。
+- `list` / `item`:同 `search`。搜索被反爬挡住时,浏览是重要的降级入口。
+
+## bookInfo —— 书详情
+
+在书详情页抽取字段(均可省略):
+
+| 字段 | 含义 |
+|------|------|
+| `name` | 书名 |
+| `author` | 作者 |
+| `cover` | 封面图 URL |
+| `intro` | 简介 |
+| `kind` | 分类 / 标签 / 状态 |
+| `lastChapter` | 最新章节名 |
+| `tocUrl` | 目录页 URL(常来自 `og:novel:read_url`) |
+| `wordCount` | 字数 |
+
+很多站点提供 `og:` meta,最稳:
+
+```json
+"bookInfo": {
+  "name":   { "via": "css", "select": "[property=\"og:novel:book_name\"]", "extract": { "attr": "content" } },
+  "tocUrl": { "via": "css", "select": "[property=\"og:novel:read_url\"]",  "extract": { "attr": "content" } }
+}
+```
+
+## toc —— 目录(章节 + 分卷)
+
+```json
+"toc": {
+  "list":     { "via": "css", "select": ".box > h2.module-title, .box a.module-row-text" },
+  "name":     { "firstOf": [ { "via":"css","select":".module-row-title","extract":"text" },
+                             { "via":"css","select":"h2","extract":"text" } ] },
+  "url":      { "via": "css", "select": "a", "extract": { "attr": "href" } },
+  "isVolume": { "via": "css", "select": "h2", "extract": "text" },
+  "maxPages": 1
+}
+```
+
+- `list` 同时选中**卷标题**与**章节链接**并保持文档顺序;`isVolume` 对卷节点求值非空、对章节为空 → 引擎据此切分「卷 → 章」生成折叠目录树。无分卷时省略 `isVolume`。
+- 目录翻页:可选 `nextPage`(选下一页链接的规则)+ `maxPages`(硬上限,默认 1)。
+
+## content —— 正文
+
+```json
+"content": {
+  "value": {
+    "via": "css", "select": ".article-content", "extract": "html",
+    "clean": [ { "regex": "请收藏本站[^<\\n]*", "replace": "" }, { "trim": true } ]
+  },
+  "maxPages": 1
+}
+```
+
+- `value`:正文抽取规则。`extract: "html"` 会把 `<p>`/`<br>` 转成换行再清理标签;`clean` 流水线去掉页脚广告等。
+- 正文分页:可选 `nextPage` + `maxPages`。
+
+## samples —— 黄金样例
+
+```json
+"samples": [
+  { "bookUrl": "/novel/guzhenren.html",
+    "expect": { "name": "蛊真人", "volumes": 8, "minChapters": 2000, "minContentChars": 500 } }
+]
+```
+
+`samples` 提供一两本真实书的期望(`name` / `minChapters` / `volumes` / `minContentChars`),供 `trn doctor` 全流程校验,也用于运行期自愈。**强烈建议至少写一条**。


### PR DESCRIPTION
## Why
书源参考还在讲已废弃的 Legado 紧凑 DSL(`bookSourceUrl` / `searchUrl` / `@css:` …),`rule`/`make` 两页是空的。与现行 `trnovel-booksource/v2` 完全脱节。

## What
按 v2 **全面重写**并**重新拆分**为 4 页(`book-source/` 主题按 `sidebar.order` 自动排序):
1. **intro** —— 本质、与旧格式区别、对 AI 友好、顶层结构一览、最小示例。
2. **structure**(新)—— `http`/`search`/`explore`/`bookInfo`/`toc`(含分卷)/`content`/`samples` 各能力形态。
3. **rules**(替换空的 `rule`)—— 叶子规则(via/select/index/extract/clean)、组合子(firstOf/concat/literal/template)、urlOrRule 与模板变量、后端选择。
4. **make** —— AI 一键(`booksource-generator` skill)与手动逆向两条路 + 常见坑 + `trn doctor` 校验 + `trn import` 导入 + 完整 bilixs 示例。

schema 链接指向自动生成的 `crates/parse-book-source/book-source.schema.json`。

## 验证
`pnpm build` 通过(18 页,组件/链接均有效)。