### PR TITLE
fix(browser): 修反爬交互的弹窗抖动/浏览器频闪/oneshot canceled(真机验证通过)

### DIFF
--- a/crates/parse-book-source/src/browser.rs
+++ b/crates/parse-book-source/src/browser.rs
@@ -20,6 +20,10 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 use tokio::sync::Mutex;
 
+/// 本会话浏览器解挑战是否已判定不可用(启动失败等)。一旦置真,后续撞挑战直接降级,
+/// **不再反复启动浏览器**(避免页面反复重跑取页时浏览器频闪)。重启 app 复位。
+static SOLVE_FAILED: AtomicBool = AtomicBool::new(false);
+
 /// 解挑战产出:可注入 reqwest 的 Cookie 头 + 浏览器真实 UA。
 ///
 /// UA 必须随 cookie 一起带走:`cf_clearance` 绑签发它的 UA(见 design D6)。
@@ -177,6 +181,12 @@ impl BrowserFetcher {
 
     /// headful 打开 `url` 解挑战,轮询取得 `cf_clearance`,返回可注入 reqwest 的 [`Clearance`]。
     pub async fn solve(&self, url: &str) -> Result<Clearance, FetchError> {
+        // 清理上次异常退出残留的单例锁:此 profile 由本 app 独占,残留 SingletonLock
+        // 会让新启动的浏览器因「profile 被占用」瞬间退出(表现为频闪 + "Browser process exit")。
+        for name in ["SingletonLock", "SingletonSocket", "SingletonCookie"] {
+            let _ = std::fs::remove_file(self.opts.profile_dir.join(name));
+        }
+
         let config = BrowserConfig::builder()
             .chrome_executable(&self.exe)
             .user_data_dir(&self.opts.profile_dir)
@@ -188,14 +198,9 @@ impl BrowserFetcher {
             .map_err(FetchError::Browser)?;
 
         let (mut browser, mut handler) = Browser::launch(config).await.map_err(browser_err)?;
-        // 驱动 CDP 连接的事件循环。
-        let handler_task = tokio::spawn(async move {
-            while let Some(ev) = handler.next().await {
-                if ev.is_err() {
-                    break;
-                }
-            }
-        });
+        // 持续驱动 CDP 连接直到关闭(stream 返回 None)。
+        // 不能因单个错误事件就退出 —— 否则会把正在进行的命令的响应通道丢掉,报 "oneshot canceled"。
+        let handler_task = tokio::spawn(async move { while handler.next().await.is_some() {} });
 
         let result = self.solve_inner(&browser, url).await;
 
@@ -328,17 +333,35 @@ impl Fetcher for EscalatingFetcher {
                 let Some(browser) = &self.browser else {
                     return Err(FetchError::Challenged(msg));
                 };
-                // 升级前征求用户授权(若提供了 UI);拒绝则降级。
-                if let Some(ui) = browser.ui()
-                    && ui.authorize(&self.name).await == AuthDecision::Deny
-                {
+                // 本会话已判定浏览器不可用 → 直接降级,不再启动(避免频闪)。
+                if SOLVE_FAILED.load(Ordering::Relaxed) {
                     return Err(FetchError::Challenged(format!(
-                        "{msg}(用户未授权浏览器辅助)"
+                        "{msg}(浏览器辅助不可用,已降级;可重启 app 重试)"
                     )));
                 }
-                let abs = self.reqwest.resolve(&req.url);
-                let c = browser.solve(&abs).await?;
-                *self.clearance.lock().await = Some(c);
+                // 串行化解挑战:持锁期间若并发的其它取页已解出 clearance,直接复用,
+                // 避免重复开浏览器 / 重复弹授权窗。
+                let mut guard = self.clearance.lock().await;
+                if guard.is_none() {
+                    // 升级前征求用户授权(若提供了 UI);拒绝则降级。
+                    if let Some(ui) = browser.ui()
+                        && ui.authorize(&self.name).await == AuthDecision::Deny
+                    {
+                        return Err(FetchError::Challenged(format!(
+                            "{msg}(用户未授权浏览器辅助)"
+                        )));
+                    }
+                    let abs = self.reqwest.resolve(&req.url);
+                    match browser.solve(&abs).await {
+                        Ok(c) => *guard = Some(c),
+                        Err(e) => {
+                            // 启动/解挑战失败:本会话停用浏览器辅助,避免反复重试导致频闪。
+                            SOLVE_FAILED.store(true, Ordering::Relaxed);
+                            return Err(e);
+                        }
+                    }
+                }
+                drop(guard);
                 self.apply_clearance(&mut req).await;
                 self.reqwest.fetch(req).await
             }

--- a/src/browser_assist.rs
+++ b/src/browser_assist.rs
@@ -4,8 +4,12 @@
 //! (见 OpenSpec change `browser-fetcher` 的 design D8/D12)。
 //!
 //! 授权两级:
-//! - **设置开关**:`~/.novel/browser_assist.on` 标记(「总是允许」),由设置页或弹窗「总是」写入;
-//! - **首次弹窗**:未设标记时,撞挑战会经 `TuiBrowserUi` 弹模态问「本次 / 总是 / 拒绝」。
+//! - **设置开关**:`~/.novel/browser_assist.on` 标记(「总是允许」),由书源管理页 B 键或弹窗「总是」写入;
+//! - **首次弹窗**:未设标记时,撞挑战会弹模态问「本次 / 总是 / 拒绝」。
+//!
+//! 关键:授权决定存于**模块级会话缓存**(非随某次取页 future 存活),`authorize` 以轮询等待。
+//! 这样并发取页、或随 query 变化被取消重启的取页,都不会叠加/抖动弹窗——只在「当前无弹窗」时
+//! 弹一次,用户决定后所有等待者复用同一决定。
 
 use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex, OnceLock};
@@ -16,20 +20,13 @@ use parse_book_source::{
     AuthDecision, BookSource, BrowserFetcher, BrowserOptions, BrowserUi, Engine, FetchMode,
 };
 use ratatui_kit::prelude::State;
-use tokio::sync::oneshot;
-
-/// 授权结果回送通道。包成 `Arc<Mutex<Option<_>>>` 以便 [`BrowserPrompt`] 可 `Clone`
-/// (`State<T>` 取值会克隆;`oneshot::Sender` 本身不可 Clone)。
-type AuthResponder = Arc<Mutex<Option<oneshot::Sender<AuthDecision>>>>;
+use tokio::time::sleep;
 
 /// 待用户处理的浏览器交互(由全局上下文 `State<Option<BrowserPrompt>>` 承载,模态组件消费)。
 #[derive(Clone)]
 pub enum BrowserPrompt {
-    /// 撞挑战、需授权:用户选「本次 / 总是 / 拒绝」,结果经 `responder` 回送。
-    Authorize {
-        source_name: String,
-        responder: AuthResponder,
-    },
+    /// 撞挑战、需授权:用户在模态里选「本次 / 总是 / 拒绝」(经 [`record_decision`] / [`set_always_allowed`] 落地)。
+    Authorize { source_name: String },
     /// 出现 Turnstile 勾选框:提示用户去浏览器点;`cancel` 置真表示取消。
     Click {
         #[allow(dead_code)]
@@ -38,14 +35,20 @@ pub enum BrowserPrompt {
     },
 }
 
-impl BrowserPrompt {
-    /// 取出授权回送通道(供模态在用户选择后 `send`)。
-    pub fn take_responder(&self) -> Option<oneshot::Sender<AuthDecision>> {
-        match self {
-            BrowserPrompt::Authorize { responder, .. } => responder.lock().ok()?.take(),
-            BrowserPrompt::Click { .. } => None,
-        }
+// ───────────────────────── 会话授权决定(本次 / 拒绝)─────────────────────────
+
+/// 本会话的「本次允许 / 拒绝」决定缓存(「总是允许」走 [`always_allowed`] 文件,见下)。
+static DECISION: Mutex<Option<AuthDecision>> = Mutex::new(None);
+
+/// 模态在用户选「本次允许 / 拒绝」后调用,记录本会话决定(「总是」不走这里,见 [`set_always_allowed`])。
+pub fn record_decision(decision: AuthDecision) {
+    if let Ok(mut d) = DECISION.lock() {
+        *d = Some(decision);
     }
+}
+
+fn cached_decision() -> Option<AuthDecision> {
+    DECISION.lock().ok().and_then(|d| *d)
 }
 
 // ───────────────────────── 持久化:「总是允许」标记 ─────────────────────────
@@ -61,7 +64,7 @@ pub fn always_allowed() -> bool {
     flag_path().map(|p| p.exists()).unwrap_or(false)
 }
 
-/// 设置 / 取消「总是允许」(供设置页开关与弹窗「总是」使用)。
+/// 设置 / 取消「总是允许」(供书源管理页 B 键开关与弹窗「总是」使用)。
 pub fn set_always_allowed(on: bool) -> std::io::Result<()> {
     let Some(p) = flag_path() else {
         return Ok(());
@@ -90,7 +93,7 @@ fn browser_ui() -> Option<Arc<dyn BrowserUi>> {
     BROWSER_UI.get().cloned()
 }
 
-/// 基于全局提示状态的 [`BrowserUi`] 实现:把交互投递到 TUI 模态并等待结果。
+/// 基于全局提示状态的 [`BrowserUi`] 实现:把交互投递到 TUI 模态,以轮询等待用户决定。
 struct TuiBrowserUi {
     state: State<Option<BrowserPrompt>>,
 }
@@ -98,20 +101,26 @@ struct TuiBrowserUi {
 #[async_trait]
 impl BrowserUi for TuiBrowserUi {
     async fn authorize(&self, source_name: &str) -> AuthDecision {
-        // 已「总是允许」→ 不打扰,直接放行。
-        if always_allowed() {
-            return AuthDecision::Always;
+        loop {
+            // 「总是允许」(设置开关 / 弹窗选总是)→ 直接放行。
+            if always_allowed() {
+                return AuthDecision::Always;
+            }
+            // 本会话已选过「本次 / 拒绝」→ 复用,不再弹窗。
+            if let Some(d) = cached_decision() {
+                return d;
+            }
+            // 仅当当前无弹窗时弹一次(并发/取消重启都不会叠加抖动)。
+            {
+                let mut st = self.state.write();
+                if st.is_none() {
+                    *st = Some(BrowserPrompt::Authorize {
+                        source_name: source_name.to_string(),
+                    });
+                }
+            }
+            sleep(Duration::from_millis(150)).await;
         }
-        let (tx, rx) = oneshot::channel();
-        // 弹授权模态(写入全局状态,触发重渲染)。
-        *self.state.write() = Some(BrowserPrompt::Authorize {
-            source_name: source_name.to_string(),
-            responder: Arc::new(Mutex::new(Some(tx))),
-        });
-        // 等用户在模态里选择(模态会经 responder 回送);取消/关闭则视为拒绝。
-        let decision = rx.await.unwrap_or(AuthDecision::Deny);
-        *self.state.write() = None;
-        decision
     }
 
     fn prompt_click(&self, url: &str, cancel: Arc<AtomicBool>) {

--- a/src/components/modal/browser_prompt.rs
+++ b/src/components/modal/browser_prompt.rs
@@ -89,15 +89,13 @@ pub fn BrowserPromptModal(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
     })
 }
 
-/// 回送授权决定;`persist_always` 时把「总是允许」落盘。
+/// 记录授权决定并撤下弹窗。`persist_always` 时把「总是允许」落盘(走文件,B 键可关);
+/// 否则把「本次 / 拒绝」记入本会话缓存。`authorize` 的轮询会随即取到。
 fn respond(state: State<Option<BrowserPrompt>>, decision: AuthDecision, persist_always: bool) {
     if persist_always {
         let _ = crate::browser_assist::set_always_allowed(true);
-    }
-    if let Some(prompt) = state.read().clone()
-        && let Some(tx) = prompt.take_responder()
-    {
-        let _ = tx.send(decision);
+    } else {
+        crate::browser_assist::record_decision(decision);
     }
     *state.write() = None;
 }


### PR DESCRIPTION
真机联调反爬交互,逐个修掉的竞态/启动问题(已端到端验证通过):

1. **授权弹窗与错误来回跳**:旧实现每次 `authorize` 新建随 future 存活的 oneshot,并发/重渲染下互相覆盖、丢 responder → 误判拒绝 → 报错又弹窗,无法按键。改为:授权决定存模块级会话缓存(`record_decision`)+ `authorize` 轮询等待;弹窗只在「当前无弹窗」时弹一次;「总是」走 `always_allowed` 文件(B 键可关)。
2. **浏览器频闪(反复启动又退出)+ `Browser process exit`**:① `EscalatingFetcher` 解挑战串行化(持 clearance 锁,期间别的取页复用,不重复开浏览器);② 会话级 `SOLVE_FAILED`:solve 一旦失败本会话停用、直接降级;③ 启动前清理本 app 独占 profile 的残留 `SingletonLock`(残留锁会让新实例瞬退)。
3. **`oneshot canceled`**:CDP handler 循环原来遇到单个错误事件就 break,会取消在途命令。改为持续驱动直到连接关闭。

## 验证
真机(macOS + Chrome)端到端跑通:撞挑战 → 授权 → 浏览器解挑战 → cf_clearance 交回 → 出结果。`clippy/test/fmt/doc --all-features` 全过。